### PR TITLE
Fix for Electron >=5.0.0 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,10 @@ function createWindow() {
     width: 800,
     height: 600,
     icon: 'src/images/icon.png',
-    show: false
+	show: false,
+	webPreferences: {
+		nodeIntegration: true
+	}
   });
 
   win.maximize();


### PR DESCRIPTION
After the upgrade to Electron 7.2.4 in #82, Sekoya fails to initialize with `Uncaught ReferenceError: require is not defined`. This is due to a security-related change in Electron 5.0.0. This PR fixes the issue by setting `webPreferences.nodeIntegration` to `true`.