### PR TITLE
Add general config option `keyScrollSpeed` (closes #72)

### DIFF
--- a/config/general.json
+++ b/config/general.json
@@ -8,5 +8,7 @@
   "//": "Folder name of the default block definition to display when opening sekoyao",
     "defaultBlocksDefinition": "awesomenauts",
   "//": "Displays debug info, enables CTRL-R to reload without saving.",
-    "debugEnabled": true
+    "debugEnabled": true,
+  "//": "Scrolling speed when using the directional camera movement keys.",
+    "keyScrollSpeed": 10
 }

--- a/src/scripts/editor/camera.js
+++ b/src/scripts/editor/camera.js
@@ -21,8 +21,6 @@ let moveUp = false,
   moveDown = false,
   moveRight = false,
   moveLeft = false;
-const SPEED = 10;
-const SCROLL_SPEED = 50;
 const ZOOM_VELOCITY = 0.1;
 
 module.exports.getPosition = () => {
@@ -172,10 +170,12 @@ module.exports.setMoveFast = (moveFast_) => {
 };
 
 module.exports.update = () => {
-  if (moveUp) setPosition(position.x, position.y - SPEED * (1 + 4 * moveFast));
-  if (moveDown) setPosition(position.x, position.y + SPEED * (1 + 4 * moveFast));
-  if (moveLeft) setPosition(position.x - SPEED * (1 + 4 * moveFast), position.y);
-  if (moveRight) setPosition(position.x + SPEED * (1 + 4 * moveFast), position.y);
+  let scrollSpeed = (config.keyScrollSpeed || 10) * (1 + 4 * moveFast);
+
+  if (moveUp) setPosition(position.x, position.y - scrollSpeed);
+  if (moveDown) setPosition(position.x, position.y + scrollSpeed);
+  if (moveLeft) setPosition(position.x - scrollSpeed, position.y);
+  if (moveRight) setPosition(position.x + scrollSpeed, position.y);
 
   if (global.mouse.buttons["2"]) {
     position.x = targetPosition.x = mouseDownPosition.x - global.mouse.canvasX;


### PR DESCRIPTION
The scrolling speed when using the directional camera movement keys (WASD by default) can now be changed via the option `keyScrollSpeed` in `config/general.json`.

For compatibility, the previously hard-coded speed of 10 is used if the option is not specified in the configuration file.

This closes #72.